### PR TITLE
support focus rect in shadow dom

### DIFF
--- a/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useMergeStylesRootStylesheets_unstable } from './MergeStylesRootContext';
 import { getDocument, getWindow } from '../dom';
+import { FocusRectsProvider } from '../FocusRectsProvider';
 
 /**
  * NOTE: This API is unstable and subject to breaking change or removal without notice.
@@ -27,22 +28,25 @@ export type MergeStylesShadowRootProviderProps = {
  * NOTE: This API is unstable and subject to breaking change or removal without notice.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const MergeStylesShadowRootProvider_unstable: React.FC<MergeStylesShadowRootProviderProps> = ({
-  shadowRoot,
-  ...props
-}) => {
+export const MergeStylesShadowRootProvider_unstable: React.FC<
+  React.PropsWithChildren<MergeStylesShadowRootProviderProps>
+> = ({ shadowRoot, ...props }) => {
   const value = React.useMemo(() => {
     return {
       stylesheets: new Map(),
       shadowRoot,
     };
   }, [shadowRoot]);
+  const focusProviderRef = React.useRef<HTMLDivElement>(null);
 
   return (
-    <MergeStylesShadowRootContext.Provider value={value} {...props} />
-    /* <GlobalStyles />
-      {props.children}
-    </MergeStylesShadowRootContext.Provider> */
+    <MergeStylesShadowRootContext.Provider value={value} {...props}>
+      <FocusRectsProvider providerRef={focusProviderRef}>
+        <div className="shadow-dom-focus-provider" ref={focusProviderRef}>
+          {props.children}
+        </div>
+      </FocusRectsProvider>
+    </MergeStylesShadowRootContext.Provider>
   );
 };
 


### PR DESCRIPTION
## Previous Behavior

Focus rect styles are not applied to Fluent components within shadow doms

## New Behavior

Added FocusRectProvider within MergeStylesShadowRootProvider.


https://github.com/spmonahan/fluentui/assets/69223766/0bc21347-1dd8-4e28-b76a-f644b916c68d


## Related Issue(s)

https://github.com/microsoft/fluentui/issues/28061

